### PR TITLE
Do not use a single chunk array for all the channel exchanges

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -235,6 +235,7 @@ func ParseVerticalFile(conf *ParserConf, lproc LineProcessor) {
 			if i == channelChunkSize {
 				i = 0
 				ch <- chunk
+				chunk = make([]interface{}, channelChunkSize)
 			}
 			progress++
 			if progress%logProgressEach == 0 {


### PR DESCRIPTION
(otherwise, the producer goroutine will overwrite
existing data the consumer processes)